### PR TITLE
Add links to source files

### DIFF
--- a/my_robot_cell/doc/assemble_urdf.rst
+++ b/my_robot_cell/doc/assemble_urdf.rst
@@ -2,7 +2,10 @@ Assembling the URDF
 ===================
 
 The `ur_description <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description>`_ package provides `macro files <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/blob/rolling/urdf/ur_macro.xacro>`_ to generate an instance of a Universal Robots arm.
-We'll use this to create a custom workcell with a ur20 inside:
+We'll use this to create a custom workcell with a ur20 inside. In this section we will only go into
+detail about the URDF / xacro files, not the complete package structure. Please see the
+`description package source code
+<https://github.com/UniversalRobots/Universal_Robots_ROS2_Tutorials/blob/main/my_robot_cell/my_robot_cell_description>`_ for all other files assembling the description package.
 
 Workcell description
 --------------------

--- a/my_robot_cell/doc/build_moveit_config.rst
+++ b/my_robot_cell/doc/build_moveit_config.rst
@@ -6,7 +6,7 @@ At this point, you should be able to run the ``ur_robot_driver`` for your custom
 Now, we are only one last step away from actually planning and executing trajectories.
 
 To utilize MoveIt! 2 for this purpose, which will handle trajectory planning for us, we need to set up a MoveIt! configuration package.
-To create such a **MoveIt! configuration package**, MoveIt! provides a very useful Setup Assistant.
+To create such a MoveIt! `configuration package <https://github.com/UniversalRobots/Universal_Robots_ROS2_Tutorials/tree/main/my_robot_cell/my_robot_cell_moveit_config>`_, MoveIt! provides a very useful Setup Assistant.
 
 Setup Assistant
 ---------------

--- a/my_robot_cell/doc/index.rst
+++ b/my_robot_cell/doc/index.rst
@@ -4,8 +4,12 @@
 Custom workcell
 ================
 
-Example about integrating an UR arm into a custom workspace.
-We will build a custom workcell description, start the driver and create a MoveIt config to enable trajectory plannin with MoveIt.
+Example about integrating an UR arm into a custom workspace. We will build a custom workcell
+description, start the driver and create a MoveIt config to enable trajectory planning with MoveIt.
+
+Please see the `package source code
+<https://github.com/UniversalRobots/Universal_Robots_ROS2_Tutorials/tree/main/my_robot_cell>`_ for
+all files relevant for this example.
 
 .. toctree::
    :maxdepth: 4

--- a/my_robot_cell/doc/start_ur_driver.rst
+++ b/my_robot_cell/doc/start_ur_driver.rst
@@ -6,7 +6,7 @@ In the last chapter we created a custom scene description containing our robot. 
 that description usable to ``ros2_control`` and hence the ``ur_robot_driver``, we need to add
 control information. We will also add a custom launchfile to startup our demonstrator.
 
-We will generate a new package called ``my_robot_cell_control`` for that purpose.
+We will generate a new package called `my_robot_cell_control <https://github.com/UniversalRobots/Universal_Robots_ROS2_Tutorials/tree/main/my_robot_cell/my_robot_cell_control>`_ for that purpose.
 
 
 Create a description with ros2_control tag


### PR DESCRIPTION
As pointed out in https://github.com/UniversalRobots/Universal_Robots_ROS2_Documentation/issues/2 it might not be clear where to look for the sources when only reading the documentation.