### PR TITLE
Remove scaled_joint_trajectory_controller

### DIFF
--- a/my_dual_robot_cell/my_dual_robot_cell_control/config/combined_controllers.yaml
+++ b/my_dual_robot_cell/my_dual_robot_cell_control/config/combined_controllers.yaml
@@ -27,12 +27,6 @@ controller_manager:
     bob_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
-    alice_scaled_joint_trajectory_controller:
-      type: ur_controllers/ScaledJointTrajectoryController
-
-    bob_scaled_joint_trajectory_controller:
-      type: ur_controllers/ScaledJointTrajectoryController
-
     forward_velocity_controller:
       type: velocity_controllers/JointGroupVelocityController
 
@@ -141,62 +135,6 @@ bob_joint_trajectory_controller:
       bob_wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
       bob_wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
       bob_wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
-
-alice_scaled_joint_trajectory_controller:
-  ros__parameters:
-    joints:
-      - alice_shoulder_pan_joint
-      - alice_shoulder_lift_joint
-      - alice_elbow_joint
-      - alice_wrist_1_joint
-      - alice_wrist_2_joint
-      - alice_wrist_3_joint
-    command_interfaces:
-      - position
-    state_interfaces:
-      - position
-      - velocity
-    state_publish_rate: 100.0
-    action_monitor_rate: 20.0
-    allow_partial_joints_goal: false
-    constraints:
-      stopped_velocity_tolerance: 0.2
-      goal_time: 0.0
-      alice_shoulder_pan_joint: { trajectory: 0.2, goal: 0.1 }
-      alice_shoulder_lift_joint: { trajectory: 0.2, goal: 0.1 }
-      alice_elbow_joint: { trajectory: 0.2, goal: 0.1 }
-      alice_wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
-      alice_wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
-      alice_wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
-    speed_scaling_interface_name: alice_speed_scaling/speed_scaling_factor
-
-bob_scaled_joint_trajectory_controller:
-  ros__parameters:
-    joints:
-      - bob_shoulder_pan_joint
-      - bob_shoulder_lift_joint
-      - bob_elbow_joint
-      - bob_wrist_1_joint
-      - bob_wrist_2_joint
-      - bob_wrist_3_joint
-    command_interfaces:
-      - position
-    state_interfaces:
-      - position
-      - velocity
-    state_publish_rate: 100.0
-    action_monitor_rate: 20.0
-    allow_partial_joints_goal: false
-    constraints:
-      stopped_velocity_tolerance: 0.2
-      goal_time: 0.0
-      bob_shoulder_pan_joint: { trajectory: 0.2, goal: 0.1 }
-      bob_shoulder_lift_joint: { trajectory: 0.2, goal: 0.1 }
-      bob_elbow_joint: { trajectory: 0.2, goal: 0.1 }
-      bob_wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
-      bob_wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
-      bob_wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
-    speed_scaling_interface_name: bob_speed_scaling/speed_scaling_factor
 
 alice_forward_velocity_controller:
   ros__parameters:

--- a/my_dual_robot_cell/my_dual_robot_cell_control/launch/start_robots.launch.py
+++ b/my_dual_robot_cell/my_dual_robot_cell_control/launch/start_robots.launch.py
@@ -396,14 +396,14 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "alice_initial_joint_controller",
-            default_value="alice_scaled_joint_trajectory_controller",
+            default_value="alice_joint_trajectory_controller",
             description="Initially loaded robot controller for the alice robot arm.",
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
             "bob_initial_joint_controller",
-            default_value="bob_scaled_joint_trajectory_controller",
+            default_value="bob_joint_trajectory_controller",
             description="Initially loaded robot controller for the bob robot arm.",
         )
     )

--- a/my_robot_cell/doc/build_moveit_config.rst
+++ b/my_robot_cell/doc/build_moveit_config.rst
@@ -56,7 +56,7 @@ We'll skip setting up ros2_control related points, since we've already configure
 control package.
 
 In the **MoveIt Controllers** step we setup our desired controller to match the name
-"scaled_joint_trajectory_controller":
+"joint_trajectory_controller":
 
 .. image:: moveit_controllers.png
    :alt: MoveIt! coontrollers configuration

--- a/my_robot_cell/my_robot_cell_control/config/ros2_controllers.yaml
+++ b/my_robot_cell/my_robot_cell_control/config/ros2_controllers.yaml
@@ -12,7 +12,7 @@ controller_manager:
     force_torque_sensor_broadcaster:
       type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
 
-    scaled_joint_trajectory_controller:
+    joint_trajectory_controller:
       type: ur_controllers/ScaledJointTrajectoryController
 
     forward_velocity_controller:
@@ -44,7 +44,7 @@ force_torque_sensor_broadcaster:
     frame_id: ur20_tool0
     topic_name: ft_data
 
-scaled_joint_trajectory_controller:
+joint_trajectory_controller:
   ros__parameters:
     joints:
       - ur20_shoulder_pan_joint

--- a/my_robot_cell/my_robot_cell_moveit_config/config/moveit_controllers.yaml
+++ b/my_robot_cell/my_robot_cell_moveit_config/config/moveit_controllers.yaml
@@ -4,9 +4,9 @@ moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControll
 
 moveit_simple_controller_manager:
   controller_names:
-    - scaled_joint_trajectory_controller
+    - joint_trajectory_controller
 
-  scaled_joint_trajectory_controller:
+  joint_trajectory_controller:
     type: FollowJointTrajectory
     action_ns: follow_joint_trajectory
     default: true


### PR DESCRIPTION
The SJTC is removed from ur_controllers for lyrical. This commit updates the tutorials to use the upstream JTC.